### PR TITLE
Bump major version to 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "expo_push_notification_client"
-version = "0.6.0"
+version = "1.0.0"
 edition = "2021"
 readme = "README.md"
 authors = ["katayama8000 <https://github.com/katayama8000>"]


### PR DESCRIPTION
Related to #140

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/katayama8000/expo-push-notification-client-rust/pull/141?shareId=e065c8b9-d56e-43f5-b7c3-5c0bd790599f).