### PR TITLE
Replace unwrap() with ? operator in tests

### DIFF
--- a/src/object/rich_content.rs
+++ b/src/object/rich_content.rs
@@ -26,7 +26,7 @@ impl RichContent {
 mod tests {
     use super::RichContent;
     use serde_json;
-    
+
     #[test]
     fn test_serialize() -> Result<(), serde_json::Error> {
         let content = RichContent::new().image("https://example.com/image.png");


### PR DESCRIPTION
Replace `unwrap()` calls with the `?` operator and proper error handling in test functions to follow Rust best practices.
